### PR TITLE
Fix for compatibility with ShowDeathCause

### DIFF
--- a/TeammateRevive/MainTeammateRevival.cs
+++ b/TeammateRevive/MainTeammateRevival.cs
@@ -342,10 +342,11 @@ namespace TeammateRevival
                 {
                     PlayerDead(victim);
                     LogInfo(victimNetworkUser.userName + " Died!");
-                    return;
                 }
-
-                LogError("Player Died but they were not alive to begin with!");
+                else
+                {
+                    LogError("Player Died but they were not alive to begin with!");
+                }
             }
 
             orig(self, damageReport, victimNetworkUser);


### PR DESCRIPTION
Replaced "return" with 'else' statement from "hook_OnPlayerCharacterDeath", preventing methods that run on it from running.

TeammateRevival hooks before the original method, then calls `return` at the end of marking a valid player as dead. I'm assuming the `return` is to skip the death message in chat? Anyways, this doesn't call `orig`, causing methods that hook after `OnPlayerCharacterDeath` to not run.

```cs
            On.RoR2.GlobalEventManager.OnPlayerCharacterDeath += (orig, self, damageReport, networkUser) =>
            {
                // I wanted to remove this initially, but this would cause any mod added before ShowDeathCause
                // in the execution cycle that relied on OnPlayerCharacterDeath to not fire.
                orig(self, damageReport, networkUser);
```

https://github.com/NotTsunami/ShowDeathCause/blob/master/ShowDeathCause/ShowDeathCause.cs#L20-L24

Although, I'm not sure how well this performs as I only did a single cursory test