### PR TITLE
Check if Transcendence exists

### DIFF
--- a/TeammateRevive/ContentManager.cs
+++ b/TeammateRevive/ContentManager.cs
@@ -26,12 +26,12 @@ namespace TeammateRevive
 
         private void LanguageOnSetStringByToken(Language.orig_SetStringByToken orig, RoR2.Language self, string token, string localizedstring)
         {
-            if (token == RoR2Content.Items.ShieldOnly.descriptionToken)
+            if (RoR2Content.Items.ShieldOnly && token == RoR2Content.Items.ShieldOnly.descriptionToken)
             {
                 localizedstring += " Teammate reviving will damage shield instead of health.";
             }
             orig(self, token, localizedstring);
-            if (token == RoR2Content.Items.ShieldOnly.descriptionToken)
+            if (RoR2Content.Items.ShieldOnly && token == RoR2Content.Items.ShieldOnly.descriptionToken)
             {
                 Log.Info($"Transcendence description ({token}) patched!");
             }


### PR DESCRIPTION
My mod `ExtendedLoadout` preloads language before RoR2Content is initalized, so your mod breaks with NRE. This will check if item exists and only then will get its token