### PR TITLE
Added a configuration option for the Post Revive Regeneration Fraction.

### DIFF
--- a/TeammateRevive/Configuration/PluginConfig.cs
+++ b/TeammateRevive/Configuration/PluginConfig.cs
@@ -231,8 +231,14 @@ namespace TeammateRevive.Configuration
                     defaultValue: values.ReviverDeathCurseChance,
                     metadata: new FloatMetadata(0, 100, 1))
                 .Bind(
-                    key: "Post revive regeneration time",
-                    description: "After reviving, 40% of revivee and linked revivers HP is restored. This value specify how long regeneration buff is active in seconds. If set to 0 - revive regen is disabled.",
+                    key: "Post Revive Regeneration Fraction",
+                    description: "After reviving, (PostReviveRegenFraction * 100%) of revivee and linked revivers HP is restored.",
+                    set: v => values.PostReviveRegenFraction = v,
+                    defaultValue: values.PostReviveRegenFraction,
+                    metadata: new FloatMetadata(0, 1, 0.05f))
+                .Bind(
+                    key: "Post Revive Regeneration Time",
+                    description: "After reviving, (PostReviveRegenFraction * 100%) of revivee and linked revivers HP is restored. This value specify how long regeneration buff is active in seconds. If set to 0 - revive regen is disabled.",
                     set: v => values.PostReviveRegenDurationSec = v,
                     defaultValue: values.PostReviveRegenDurationSec,
                     metadata: new FloatMetadata(0, 30, 1)

--- a/TeammateRevive/Revive/RevivalTracker.cs
+++ b/TeammateRevive/Revive/RevivalTracker.cs
@@ -195,7 +195,7 @@ namespace TeammateRevive.Revive
                 player.RemoveReviveLink(dead);
             
             // add post-revive regeneration to revivers
-            if (rules.Values.PostReviveRegenDurationSec != 0)
+            if (rules.Values.PostReviveRegenFraction != 0 && rules.Values.PostReviveRegenDurationSec != 0)
             {
                 foreach (var player in linkedPlayers)
                     player.GetBody().AddTimedBuff(ReviveRegen.Index, rules.Values.PostReviveRegenDurationSec);

--- a/TeammateRevive/Revive/Rules/SetRulesMessage.cs
+++ b/TeammateRevive/Revive/Rules/SetRulesMessage.cs
@@ -35,6 +35,7 @@ namespace TeammateRevive.Revive.Rules
             writer.Write(ruleValues.DebugKeepTotem);
             writer.Write(ruleValues.EnableRevivalToken);
             writer.Write(ruleValues.CutReviveeHp);
+            writer.Write(ruleValues.PostReviveRegenFraction);
             writer.Write(ruleValues.PostReviveRegenDurationSec);
             Log.Info("Sending new rule values");
         }
@@ -55,6 +56,7 @@ namespace TeammateRevive.Revive.Rules
             ruleValues.DebugKeepTotem = reader.ReadBoolean();
             ruleValues.EnableRevivalToken = reader.ReadBoolean();
             ruleValues.CutReviveeHp = reader.ReadBoolean();
+            ruleValues.PostReviveRegenFraction = reader.ReadSingle();
             ruleValues.PostReviveRegenDurationSec = reader.ReadSingle();
         }
 


### PR DESCRIPTION
The user can now change the percent of max health that is restored to both the reviver and revivee after a successful revive. (PostReviveRegenFraction)

I just felt like this option was missing. I was going to just create an issue suggestion but figured I would at least **_try_** to add it myself.

Thanks for the awesome mod! :]